### PR TITLE
Fixes issue 89

### DIFF
--- a/src/charts/lineChart.js
+++ b/src/charts/lineChart.js
@@ -77,7 +77,8 @@ export const addLineChart = (inputOptions, config) => {
     var titleOffset = document.getElementById(inputOptions.id).offsetWidth / 2
 
     d3.selectAll('.nv-axisMax-y').remove()
-
+    
+    d3.select(id + ' svg').select('svg > text').remove();
     d3.select(id + ' svg')
       .append('text')
       .attr('x', titleOffset)

--- a/src/charts/lineChart.js
+++ b/src/charts/lineChart.js
@@ -77,8 +77,8 @@ export const addLineChart = (inputOptions, config) => {
     var titleOffset = document.getElementById(inputOptions.id).offsetWidth / 2
 
     d3.selectAll('.nv-axisMax-y').remove()
-    
-    d3.select(id + ' svg').select('svg > text').remove();
+
+    d3.select(id + ' svg').select('svg > text').remove()
     d3.select(id + ' svg')
       .append('text')
       .attr('x', titleOffset)


### PR DESCRIPTION
addGraph method was appending the text tag without removing the previous
ones. This commit ensures that previously added text tag is removed
before new one is added. Hence, preventing the overlapping.