### PR TITLE
Move polyfill to load earlier in the page

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -24,7 +24,6 @@ const webpackConfig = {
 // Entry Points
 // ------------------------------------
 const APP_ENTRY_PATHS = [
-  'babel-polyfill',
   paths.client('main.js')
 ]
 
@@ -32,7 +31,7 @@ webpackConfig.entry = {
   app: __DEV__
     ? APP_ENTRY_PATHS.concat(`webpack-hot-middleware/client?path=${config.compiler_public_path}__webpack_hmr`)
     : APP_ENTRY_PATHS,
-  vendor: config.compiler_vendor
+  vendor: ['babel-polyfill'].concat(config.compiler_vendor)
 }
 
 // ------------------------------------


### PR DESCRIPTION
This PR moves the polyfill to load earlier in the page, with the vendor JavaScript, instead of the app's Javascript.  

This was previously causing some vendor libraries to not be able to use the polyfill code, which would cause errors in IE11 and Android browsers, due to `react-optimize`, as noted in this issue:

https://github.com/thejameskyle/babel-react-optimize/issues/16

Reviewers: @LaurieSReynolds @mthong 